### PR TITLE
Update codeceptjs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ defaults: &defaults
     - run:
         name: Run tests
         command: |
-          docker create --network host --name tester codeception/codeceptjs codeceptjs run-multiple --all --steps --verbose
+          docker create --network host --name tester codeceptjs/codeceptjs codeceptjs run-multiple --all --steps --verbose
           docker cp $(pwd)/lock_login_spa_test.js tester:/tests/lock_login_test.js
           docker cp $(pwd)/codecept.conf.js tester:/tests/codecept.conf.js
           docker start -i tester
@@ -48,7 +48,7 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: git clone https://github.com/auth0-samples/spa-quickstarts-tests scripts
+      - run: git clone --branch chore/update-deps https://github.com/auth0-samples/spa-quickstarts-tests scripts
       - persist_to_workspace:
           root: ~/
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: git clone --branch chore/update-deps https://github.com/auth0-samples/spa-quickstarts-tests scripts
+      - run: git clone https://github.com/auth0-samples/spa-quickstarts-tests scripts
       - persist_to_workspace:
           root: ~/
           paths:


### PR DESCRIPTION
We are using an incorrect docker image that hasn't been updated for 3 years: https://hub.docker.com/r/codeception/codeceptjs

Instead, we should be using https://hub.docker.com/r/codeceptjs/codeceptjs instead.